### PR TITLE
Increased Buffer Size - Fix for #71

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -307,7 +307,7 @@ class CodingPanel {
                 var p = new Promise(resolve => {
                     let sfdxCmd = "sfdx force:mdapi:listmetadata -a " + this.VERSION_NUM + " --json -m " + mType;
                     let foo = child.exec(sfdxCmd, {
-                        maxBuffer: 1024 * 1024 * 6,
+                        maxBuffer: 1024 * 1024 * 8,
                         cwd: vscode.workspace.workspaceFolders[0].uri.fsPath
                     });
                     let bufferOutData = '';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -401,7 +401,7 @@ class CodingPanel {
 				var p = new Promise(resolve => {
 					let sfdxCmd ="sfdx force:mdapi:listmetadata -a "+this.VERSION_NUM+" --json -m "+mType;
 					let foo: child.ChildProcess = child.exec(sfdxCmd,{
-						maxBuffer: 1024 * 1024 * 6,
+						maxBuffer: 1024 * 1024 * 8,
 						cwd: vscode.workspace.workspaceFolders[0].uri.fsPath
 					});
 


### PR DESCRIPTION
Increased buffer size for listing custom metadata.

We found error #71 was caused by more custom fields than the buffer could hold.
The error was resolved by increasing the buffer.