### PR TITLE
Fix: allow Roboto fonts to load and apply correctly from GoogleFonts static site

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1084,7 +1084,8 @@ private getMetadataTypes(mpExistingPackageXML){
 			  	<meta http-equiv="Content-Security-Policy" content="default-src; 
 			  connect-src vscode-resource: https: ${cspSource};
 			  img-src vscode-resource: https: ${cspSource} ${resourcePathUri}; style-src 'unsafe-inline' vscode-resource: https: ${cspSource}; 
-			  script-src 'self' 'unsafe-inline' 'unsafe-eval' vscode-resource: https: ${cspSource}">
+			  script-src 'self' 'unsafe-inline' 'unsafe-eval' vscode-resource: https: ${cspSource};
+			  font-src 'self' https://fonts.gstatic.com">
 
 				<meta name="viewport" content="width=device-width, initial-scale=1.0">
 				<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jstree/3.2.1/themes/default/style.min.css" />


### PR DESCRIPTION
## Problem
Extension's main window was not able to load the Roboto fonts because they are supplied from the `https://fonts.gstatic.com` site, which wasn't satisfying the Content Security Policy's `default-src;` directive. 
A bunch of errors similar to the one below were thrown to the VSCode's Developer Tools console:
`Refused to load the font 'https://fonts.gstatic.com/s/roboto/v47/KFO7CnqEu92Fr1ME7kSn66aGLdTylUAMa3KUBGEe.woff2' because it violates the following Content Security Policy directive: "default-src ". Note that 'font-src' was not explicitly set, so 'default-src' is used as a fallback.`
As a result, extension was falling back to the Arial font:
![image](https://github.com/user-attachments/assets/f4110633-c9d4-468f-a12b-af368627d274)

## Fix
Add the `font-src 'self' https://fonts.gstatic.com` CSP directive.

After the change, Roboto font is downloaded and applied correctly, and no font-related errors appear on the VSCode Dev Tools console:
![image](https://github.com/user-attachments/assets/c277bf73-2d5c-4bf0-8bef-52b4e30705ea)
