### PR TITLE
Fix: Increased the buffer size for larger orgs

### DIFF
--- a/out/extension.js
+++ b/out/extension.js
@@ -395,7 +395,7 @@ class CodingPanel {
                 var p = new Promise(resolve => {
                     let sfdxCmd = "sf org list metadata --api-version " + this.VERSION_NUM + " --json -m " + mType;
                     let foo = child.exec(sfdxCmd, {
-                        maxBuffer: 1024 * 1024 * 8,
+                        maxBuffer: 1024 * 1024 * 100,
                         cwd: vscode.workspace.workspaceFolders[0].uri.fsPath
                     });
                     let bufferOutData = '';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -449,7 +449,7 @@ class CodingPanel {
 				var p = new Promise<void>(resolve => {
 					let sfdxCmd ="sf org list metadata --api-version "+this.VERSION_NUM+" --json -m "+mType;
 					let foo: child.ChildProcess = child.exec(sfdxCmd,{
-						maxBuffer: 1024 * 1024 * 8,
+						maxBuffer: 1024 * 1024 * 100,
 						cwd: vscode.workspace.workspaceFolders[0].uri.fsPath
 					});
 


### PR DESCRIPTION
Simply increased the buffer size.

This should fix the issue https://github.com/vignaesh01/sfdx-package-generator/issues/120

I had this issue with a new LSC org as it has a ton of custom fields coming from pre-installed packages (Industry Solutions and stuff) and the metadata request would return over 8MB of JSON data, which then would get truncated due to the max buffer size of 8MB set for the `child_process`.