### PR TITLE
Select All Upgrade

### DIFF
--- a/client/src/components/ComponentList.js
+++ b/client/src/components/ComponentList.js
@@ -70,7 +70,8 @@ export default function ComponentList({selectedMetadataType,isShowChildren}) {
 
   const handleSelectAll = ()=>{
     selectedMetadataType.children=selectedMetadataType.children.map(child=>{
-      child.isSelected=true;//update the child state 
+	    if(child.text.toUpperCase().includes(filterKey.toUpperCase()))
+     		 child.isSelected=true;//update the child state 
       return child;
     });
 


### PR DESCRIPTION
Now when clicking "select all" button in component list, only the search filtered child components will be selected  instead of all child components. #148 #30 