### PR TITLE
Fix: Select All on Filter search

### DIFF
--- a/client/src/components/ComponentList.js
+++ b/client/src/components/ComponentList.js
@@ -69,14 +69,18 @@ export default function ComponentList({selectedMetadataType,isShowChildren}) {
   };
 
   const handleSelectAll = ()=>{
+    const isIndeterminateFilter = false
     selectedMetadataType.children=selectedMetadataType.children.map(child=>{
+      if(filterKey !== '' && child.text.toUpperCase().includes(filterKey.toUpperCase())){
+        child.isSelected=true
+        return child;
+      }
       child.isSelected=true;//update the child state 
       return child;
     });
 
     //ALl the children are selected
-    selectedMetadataType.isSelected=true;
-    selectedMetadataType.isIndeterminate=false;
+    selectedMetadataType=updateMetadataType(selectedMetadataType)
     dispatch({type: "COMPONENT_CHECKBOX_STATE_CHANGE" , payload : selectedMetadataType});
   };
 

--- a/client/src/components/ComponentList.js
+++ b/client/src/components/ComponentList.js
@@ -68,20 +68,25 @@ export default function ComponentList({selectedMetadataType,isShowChildren}) {
 
   };
 
-  const handleSelectAll = ()=>{
+
+  const handleSelectAll = () => {
     const isIndeterminateFilter = false
-    selectedMetadataType.children=selectedMetadataType.children.map(child=>{
-      if(filterKey !== '' && child.text.toUpperCase().includes(filterKey.toUpperCase())){
-        child.isSelected=true
+    selectedMetadataType.children = selectedMetadataType.children.map(child => {
+      if (filterKey === '') {
+        child.isSelected = true;//update the child state 
+        return child;
+      } else if (filterKey !== '' && child.text.toUpperCase().includes(filterKey.toUpperCase())) {
+        child.isSelected = true
+        return child;
+      } else {
+        child.isSelected = true;//update the child state 
         return child;
       }
-      child.isSelected=true;//update the child state 
-      return child;
     });
 
     //ALl the children are selected
-    selectedMetadataType=updateMetadataType(selectedMetadataType)
-    dispatch({type: "COMPONENT_CHECKBOX_STATE_CHANGE" , payload : selectedMetadataType});
+    selectedMetadataType = updateMetadataType(selectedMetadataType)
+    dispatch({type: "COMPONENT_CHECKBOX_STATE_CHANGE", payload: selectedMetadataType});
   };
 
   const handleClearAll = ()=>{

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "sfdx-package-xml-generator",
-	"version": "2.0.14",
+	"version": "2.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "sfdx-package-xml-generator",
-			"version": "2.0.14",
+			"version": "2.1.0",
 			"dependencies": {
 				"clipboardy": "^4.0.0",
 				"xml2js": "^0.4.23"


### PR DESCRIPTION
The Select All functionality now works for both filtered and non-filtered labels.
I’ve added the necessary conditions to ensure it respects the applied filter keywords.

This update also aligns with the following issue tickets for reference:

[#148](https://github.com/vignaesh01/sfdx-package-generator/issues/148), [#30](https://github.com/vignaesh01/sfdx-package-generator/issues/30)

Please let me know if any further adjustments are needed.

Best regards,
Salman